### PR TITLE
Bump object-path and resolve-url-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "laravel-mix": "^6.0.49",
                 "lodash": "^4.17.21",
                 "popper.js": "^1.12",
-                "resolve-url-loader": "^2.3.1",
+                "resolve-url-loader": "^5.0.0",
                 "sass": "^1.49.0",
                 "sass-loader": "7.*",
                 "vue": "^2.6.14",
@@ -2519,74 +2519,16 @@
             }
         },
         "node_modules/adjust-sourcemap-loader": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
-            "integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+            "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
             "dev": true,
             "dependencies": {
-                "assert": "^1.3.0",
-                "camelcase": "^1.2.1",
-                "loader-utils": "^1.1.0",
-                "lodash.assign": "^4.0.1",
-                "lodash.defaults": "^3.1.2",
-                "object-path": "^0.9.2",
-                "regex-parser": "^2.2.9"
-            }
-        },
-        "node_modules/adjust-sourcemap-loader/node_modules/camelcase": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/adjust-sourcemap-loader/node_modules/json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
+                "loader-utils": "^2.0.0",
+                "regex-parser": "^2.2.11"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/adjust-sourcemap-loader/node_modules/lodash.defaults": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-            "integrity": "sha512-X7135IXFQt5JDFnYxOVAzVz+kFvwDn3N8DJYf+nrz/mMWEuSu7+OL6rWqsk3+VR1T4TejFCSu5isBJOLSID2bg==",
-            "dev": true,
-            "dependencies": {
-                "lodash.assign": "^3.0.0",
-                "lodash.restparam": "^3.0.0"
-            }
-        },
-        "node_modules/adjust-sourcemap-loader/node_modules/lodash.defaults/node_modules/lodash.assign": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-            "integrity": "sha512-/VVxzgGBmbphasTg51FrztxQJ/VgAUpol6zmJuSVSGcNg4g7FA4z7rQV8Ovr9V3vFBNWZhvKWHfpAytjTVUfFA==",
-            "dev": true,
-            "dependencies": {
-                "lodash._baseassign": "^3.0.0",
-                "lodash._createassigner": "^3.0.0",
-                "lodash.keys": "^3.0.0"
+                "node": ">=8.9"
             }
         },
         "node_modules/admin-lte": {
@@ -2957,6 +2899,7 @@
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "atob": "bin/atob.js"
             },
@@ -3620,15 +3563,6 @@
             "dependencies": {
                 "pascal-case": "^3.1.2",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/caniuse-api": {
@@ -4323,18 +4257,6 @@
             "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
             "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
         },
-        "node_modules/css": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.5.2",
-                "urix": "^0.1.0"
-            }
-        },
         "node_modules/css-declaration-sorter": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
@@ -4909,6 +4831,7 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -8557,102 +8480,16 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "node_modules/lodash._baseassign": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
-            "dev": true,
-            "dependencies": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash.keys": "^3.0.0"
-            }
-        },
-        "node_modules/lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
-            "dev": true
-        },
-        "node_modules/lodash._bindcallback": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-            "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
-            "dev": true
-        },
-        "node_modules/lodash._createassigner": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-            "integrity": "sha512-LziVL7IDnJjQeeV95Wvhw6G28Z8Q6da87LWKOPWmzBLv4u6FAT/x5v00pyGW0u38UoogNF2JnD3bGgZZDaNEBw==",
-            "dev": true,
-            "dependencies": {
-                "lodash._bindcallback": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash.restparam": "^3.0.0"
-            }
-        },
-        "node_modules/lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
-            "dev": true
-        },
-        "node_modules/lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ==",
-            "dev": true
-        },
-        "node_modules/lodash.assign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-            "dev": true
-        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
         },
-        "node_modules/lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-            "dev": true
-        },
-        "node_modules/lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-            "dev": true
-        },
-        "node_modules/lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
-            "dev": true
-        },
-        "node_modules/lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
-            "dev": true,
-            "dependencies": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-            }
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "dev": true
-        },
-        "node_modules/lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw==",
             "dev": true
         },
         "node_modules/lodash.uniq": {
@@ -9586,15 +9423,6 @@
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/object-path": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-            "integrity": "sha512-hPv/mbCYtXOhhqstmodis0boF1ooA8yz3PDJwTnkZvOlaJkd5aCAgA9tq6BUjJW5w8jXHI2qi9+w5N0tz+AAaA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/object-visit": {
@@ -11142,58 +10970,23 @@
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
             "deprecated": "https://github.com/lydell/resolve-url#deprecated",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/resolve-url-loader": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.3.2.tgz",
-            "integrity": "sha512-sc/UVgiADdoTc+4cGPB7cUCnlEkzlxD1NXHw4oa9qA0fp30H8mAQ2ePJBP9MQ029DUuhEPouhNdvzT37pBCV0g==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+            "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
             "dev": true,
             "dependencies": {
-                "adjust-sourcemap-loader": "^1.1.0",
-                "camelcase": "^4.1.0",
-                "convert-source-map": "^1.5.1",
-                "loader-utils": "^1.1.0",
-                "lodash.defaults": "^4.0.0",
-                "rework": "^1.0.1",
-                "rework-visit": "^1.0.0",
-                "source-map": "^0.5.7",
-                "urix": "^0.1.0"
-            }
-        },
-        "node_modules/resolve-url-loader/node_modules/json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
-            }
-        },
-        "node_modules/resolve-url-loader/node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-            "dev": true,
-            "dependencies": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
+                "adjust-sourcemap-loader": "^4.0.0",
+                "convert-source-map": "^1.7.0",
+                "loader-utils": "^2.0.0",
+                "postcss": "^8.2.14",
+                "source-map": "0.6.1"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/resolve-url-loader/node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12"
             }
         },
         "node_modules/ret": {
@@ -11224,28 +11017,6 @@
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/rework": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
-            "integrity": "sha512-eEjL8FdkdsxApd0yWVZgBGzfCQiT8yqSc2H1p4jpZpQdtz7ohETiDMoje5PlM8I9WgkqkreVxFUKYOiJdVWDXw==",
-            "dev": true,
-            "dependencies": {
-                "convert-source-map": "^0.3.3",
-                "css": "^2.0.0"
-            }
-        },
-        "node_modules/rework-visit": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
-            "integrity": "sha512-W6V2fix7nCLUYX1v6eGPrBOZlc03/faqzP4sUxMAJMBMOPYhfV/RyLegTufn5gJKaOITyi+gvf0LXDZ9NzkHnQ==",
-            "dev": true
-        },
-        "node_modules/rework/node_modules/convert-source-map": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-            "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg==",
-            "dev": true
         },
         "node_modules/rimraf": {
             "version": "2.7.1",
@@ -12068,6 +11839,7 @@
             "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "atob": "^2.1.2",
                 "decode-uri-component": "^0.2.0",
@@ -12091,7 +11863,8 @@
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
             "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/sourcemap-codec": {
             "version": "1.4.8",
@@ -13065,7 +12838,8 @@
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
             "deprecated": "Please see https://github.com/lydell/urix#deprecated",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/url": {
             "version": "0.11.0",
@@ -16413,69 +16187,13 @@
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
         },
         "adjust-sourcemap-loader": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
-            "integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+            "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
             "dev": true,
             "requires": {
-                "assert": "^1.3.0",
-                "camelcase": "^1.2.1",
-                "loader-utils": "^1.1.0",
-                "lodash.assign": "^4.0.1",
-                "lodash.defaults": "^3.1.2",
-                "object-path": "^0.9.2",
-                "regex-parser": "^2.2.9"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
-                    "dev": true
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
-                "lodash.defaults": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-                    "integrity": "sha512-X7135IXFQt5JDFnYxOVAzVz+kFvwDn3N8DJYf+nrz/mMWEuSu7+OL6rWqsk3+VR1T4TejFCSu5isBJOLSID2bg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash.assign": "^3.0.0",
-                        "lodash.restparam": "^3.0.0"
-                    },
-                    "dependencies": {
-                        "lodash.assign": {
-                            "version": "3.2.0",
-                            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-                            "integrity": "sha512-/VVxzgGBmbphasTg51FrztxQJ/VgAUpol6zmJuSVSGcNg4g7FA4z7rQV8Ovr9V3vFBNWZhvKWHfpAytjTVUfFA==",
-                            "dev": true,
-                            "requires": {
-                                "lodash._baseassign": "^3.0.0",
-                                "lodash._createassigner": "^3.0.0",
-                                "lodash.keys": "^3.0.0"
-                            }
-                        }
-                    }
-                }
+                "loader-utils": "^2.0.0",
+                "regex-parser": "^2.2.11"
             }
         },
         "admin-lte": {
@@ -16784,7 +16502,8 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "autoprefixer": {
             "version": "10.4.12",
@@ -17317,12 +17036,6 @@
                 "pascal-case": "^3.1.2",
                 "tslib": "^2.0.3"
             }
-        },
-        "camelcase": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-            "dev": true
         },
         "caniuse-api": {
             "version": "3.0.0",
@@ -17900,18 +17613,6 @@
             "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
             "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
         },
-        "css": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-            "dev": true,
-            "requires": {
-                "inherits": "^2.0.3",
-                "source-map": "^0.6.1",
-                "source-map-resolve": "^0.5.2",
-                "urix": "^0.1.0"
-            }
-        },
         "css-declaration-sorter": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
@@ -18402,7 +18103,8 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "deep-equal": {
             "version": "1.1.1",
@@ -21226,102 +20928,16 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "lodash._baseassign": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-            "integrity": "sha512-t3N26QR2IdSN+gqSy9Ds9pBu/J1EAFEshKlUHpJG3rvyJOYgcELIxcIeKKfZk7sjOz11cFfzJRsyFry/JyabJQ==",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash.keys": "^3.0.0"
-            }
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha512-rFR6Vpm4HeCK1WPGvjZSJ+7yik8d8PVUdCJx5rT2pogG4Ve/2ZS7kfmO5l5T2o5V2mqlNIfSF5MZlr1+xOoYQQ==",
-            "dev": true
-        },
-        "lodash._bindcallback": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-            "integrity": "sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==",
-            "dev": true
-        },
-        "lodash._createassigner": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-            "integrity": "sha512-LziVL7IDnJjQeeV95Wvhw6G28Z8Q6da87LWKOPWmzBLv4u6FAT/x5v00pyGW0u38UoogNF2JnD3bGgZZDaNEBw==",
-            "dev": true,
-            "requires": {
-                "lodash._bindcallback": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash.restparam": "^3.0.0"
-            }
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha512-De+ZbrMu6eThFti/CSzhRvTKMgQToLxbij58LMfM8JnYDNSOjkjTCIaa8ixglOeGh2nyPlakbt5bJWJ7gvpYlQ==",
-            "dev": true
-        },
-        "lodash.assign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
-            "dev": true
-        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
         },
-        "lodash.defaults": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-            "dev": true
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==",
-            "dev": true
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha512-CuBsapFjcubOGMn3VD+24HOAPxM79tH+V6ivJL3CHYjtrawauDJHUk//Yew9Hvc6e9rbCrURGk8z6PC+8WJBfQ==",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
-            }
-        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-            "dev": true
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw==",
             "dev": true
         },
         "lodash.uniq": {
@@ -22080,12 +21696,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-        },
-        "object-path": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-            "integrity": "sha512-hPv/mbCYtXOhhqstmodis0boF1ooA8yz3PDJwTnkZvOlaJkd5aCAgA9tq6BUjJW5w8jXHI2qi9+w5N0tz+AAaA==",
-            "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
@@ -23206,51 +22816,20 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "resolve-url-loader": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.3.2.tgz",
-            "integrity": "sha512-sc/UVgiADdoTc+4cGPB7cUCnlEkzlxD1NXHw4oa9qA0fp30H8mAQ2ePJBP9MQ029DUuhEPouhNdvzT37pBCV0g==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+            "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
             "dev": true,
             "requires": {
-                "adjust-sourcemap-loader": "^1.1.0",
-                "camelcase": "^4.1.0",
-                "convert-source-map": "^1.5.1",
-                "loader-utils": "^1.1.0",
-                "lodash.defaults": "^4.0.0",
-                "rework": "^1.0.1",
-                "rework-visit": "^1.0.0",
-                "source-map": "^0.5.7",
-                "urix": "^0.1.0"
-            },
-            "dependencies": {
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-                    "dev": true
-                }
+                "adjust-sourcemap-loader": "^4.0.0",
+                "convert-source-map": "^1.7.0",
+                "loader-utils": "^2.0.0",
+                "postcss": "^8.2.14",
+                "source-map": "0.6.1"
             }
         },
         "ret": {
@@ -23270,30 +22849,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true
-        },
-        "rework": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
-            "integrity": "sha512-eEjL8FdkdsxApd0yWVZgBGzfCQiT8yqSc2H1p4jpZpQdtz7ohETiDMoje5PlM8I9WgkqkreVxFUKYOiJdVWDXw==",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "^0.3.3",
-                "css": "^2.0.0"
-            },
-            "dependencies": {
-                "convert-source-map": {
-                    "version": "0.3.5",
-                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-                    "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg==",
-                    "dev": true
-                }
-            }
-        },
-        "rework-visit": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz",
-            "integrity": "sha512-W6V2fix7nCLUYX1v6eGPrBOZlc03/faqzP4sUxMAJMBMOPYhfV/RyLegTufn5gJKaOITyi+gvf0LXDZ9NzkHnQ==",
             "dev": true
         },
         "rimraf": {
@@ -23960,6 +23515,7 @@
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
             "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "atob": "^2.1.2",
                 "decode-uri-component": "^0.2.0",
@@ -23982,7 +23538,8 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "sourcemap-codec": {
             "version": "1.4.8",
@@ -24755,7 +24312,8 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "url": {
             "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "laravel-mix": "^6.0.49",
         "lodash": "^4.17.21",
         "popper.js": "^1.12",
-        "resolve-url-loader": "^2.3.1",
+        "resolve-url-loader": "^5.0.0",
         "sass": "^1.49.0",
         "sass-loader": "7.*",
         "vue": "^2.6.14",


### PR DESCRIPTION
Removes [object-path](https://github.com/mariocasciaro/object-path). It's no longer used after updating ancestor dependency [resolve-url-loader](https://github.com/bholloway/resolve-url-loader/tree/HEAD/packages/resolve-url-loader). These dependencies need to be updated together.


Removes `object-path`

Updates `resolve-url-loader` from 2.3.2 to 5.0.0
- [Release notes](https://github.com/bholloway/resolve-url-loader/releases)
- [Changelog](https://github.com/bholloway/resolve-url-loader/blob/v5/packages/resolve-url-loader/CHANGELOG.md)
- [Commits](https://github.com/bholloway/resolve-url-loader/commits/5.0.0/packages/resolve-url-loader)

---
updated-dependencies:
- dependency-name: object-path dependency-type: indirect
- dependency-name: resolve-url-loader dependency-type: direct:development ...

Signed-off-by: dependabot[bot] <support@github.com>